### PR TITLE
Harden GitHub Actions: pin actions to SHAs and set explicit permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,10 @@ on:
 
 # Prevent two release workflows from running concurrently, which might cause write-after-read race conditions in the repository's gh-pages branch
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+
+permissions:
+  contents: read
+
 concurrency: helm-release
 
 jobs:
@@ -18,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -28,6 +32,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -9,16 +9,20 @@ on:
 
 # Prevent two release workflows from running concurrently, which might cause write-after-read race conditions in the repository's gh-pages branch
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+
+permissions:
+  contents: read
+
 concurrency: sync-readme
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: |
           cp -f README.md ${{ runner.temp }}/README.md
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: gh-pages
       - run: |


### PR DESCRIPTION
## Harden GitHub Actions workflows

- Pin all action/workflow references to immutable commit SHAs
- Add explicit minimal `permissions` blocks

**Why**: Prevents supply chain attacks where a tag could be moved to point to malicious code. Explicit permissions reduce blast radius if a workflow is compromised.